### PR TITLE
Add test coverage

### DIFF
--- a/cmd/board_test.go
+++ b/cmd/board_test.go
@@ -1,0 +1,140 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/mattn/go-runewidth"
+	"github.com/maxbeizer/gh-planning/internal/github"
+)
+
+func TestPadOrTruncate_PlainASCII(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		width int
+		want  int // expected visual width
+	}{
+		{"short padded", "hello", 10, 10},
+		{"exact fit", "hello", 5, 5},
+		{"empty string", "", 5, 5},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := padOrTruncate(tt.input, tt.width)
+			got := visualWidth(result)
+			if got != tt.want {
+				t.Errorf("padOrTruncate(%q, %d) visual width = %d, want %d (result=%q)", tt.input, tt.width, got, tt.want, result)
+			}
+		})
+	}
+}
+
+func TestPadOrTruncate_Emoji(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		width int
+	}{
+		{"crab emoji padded", "🦀 hello", 15},
+		{"clipboard emoji padded", "📋 Backlog", 15},
+		{"check emoji padded", "✅ Done", 15},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := padOrTruncate(tt.input, tt.width)
+			got := visualWidth(result)
+			if got != tt.width {
+				t.Errorf("padOrTruncate(%q, %d) visual width = %d, want %d (result=%q)", tt.input, tt.width, got, tt.width, result)
+			}
+		})
+	}
+}
+
+func TestPadOrTruncate_Truncation(t *testing.T) {
+	long := "This is a very long string that should be truncated"
+	result := padOrTruncate(long, 10)
+	got := visualWidth(result)
+	if got != 10 {
+		t.Errorf("truncated visual width = %d, want 10 (result=%q)", got, result)
+	}
+}
+
+func TestPadOrTruncate_TruncationWithEmoji(t *testing.T) {
+	s := "🔵 In Progress with lots of text"
+	result := padOrTruncate(s, 12)
+	got := visualWidth(result)
+	if got != 12 {
+		t.Errorf("truncated emoji visual width = %d, want 12 (result=%q)", got, result)
+	}
+}
+
+func TestSortedStatuses_Order(t *testing.T) {
+	groups := map[string][]github.ProjectItem{
+		"Done":        {},
+		"In Progress": {},
+		"Backlog":     {},
+		"In Review":   {},
+	}
+	result := sortedStatuses(groups)
+	expected := []string{"Backlog", "In Progress", "In Review", "Done"}
+	if len(result) != len(expected) {
+		t.Fatalf("sortedStatuses length = %d, want %d", len(result), len(expected))
+	}
+	for i, got := range result {
+		if got != expected[i] {
+			t.Errorf("sortedStatuses[%d] = %q, want %q", i, got, expected[i])
+		}
+	}
+}
+
+func TestSortedStatuses_UnknownStatusLast(t *testing.T) {
+	groups := map[string][]github.ProjectItem{
+		"Backlog": {},
+		"Custom":  {},
+		"Done":    {},
+	}
+	result := sortedStatuses(groups)
+	// Custom should come between Backlog and Done since it has max rank
+	// but alphabetically. Actually: Backlog(0), Done(7), Custom(len=11).
+	// So: Backlog, Done, Custom
+	if result[0] != "Backlog" {
+		t.Errorf("first status = %q, want Backlog", result[0])
+	}
+	if result[len(result)-1] != "Custom" {
+		t.Errorf("last status = %q, want Custom", result[len(result)-1])
+	}
+}
+
+func TestStatusEmoji(t *testing.T) {
+	tests := []struct {
+		status string
+		want   string
+	}{
+		{"In Progress", "🔵"},
+		{"in progress", "🔵"},
+		{"Backlog", "📋"},
+		{"Ready", "📋"},
+		{"Todo", "📋"},
+		{"Done", "✅"},
+		{"Closed", "✅"},
+		{"Complete", "✅"},
+		{"Completed", "✅"},
+		{"In Review", "🔍"},
+		{"Needs Review", "🔍"},
+		{"Needs My Attention", "🔍"},
+		{"Blocked", "🚫"},
+		{"Something Else", "•"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			got := statusEmoji(tt.status)
+			if got != tt.want {
+				t.Errorf("statusEmoji(%q) = %q, want %q", tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
+func visualWidth(s string) int {
+	return runewidth.StringWidth(s)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,7 +26,14 @@ type configFile struct {
 	Profiles      map[string]Config `yaml:"profiles,omitempty"`
 }
 
+// dirOverride, when non-empty, replaces the default config directory.
+// Used by tests to redirect config I/O to a temp directory.
+var dirOverride string
+
 func Dir() (string, error) {
+	if dirOverride != "" {
+		return dirOverride, nil
+	}
 	base, err := os.UserConfigDir()
 	if err != nil {
 		return "", err

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,292 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+func setup(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	dirOverride = dir
+	t.Cleanup(func() { dirOverride = "" })
+}
+
+func writeConfig(t *testing.T, content string) {
+	t.Helper()
+	p, err := Path()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoad_NoFile(t *testing.T) {
+	setup(t)
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.DefaultOwner != "" || cfg.DefaultProject != 0 {
+		t.Errorf("expected empty config, got %+v", cfg)
+	}
+}
+
+func TestLoad_LegacyConfig(t *testing.T) {
+	setup(t)
+	writeConfig(t, `
+default-project: 42
+default-owner: acme
+team:
+  - alice
+  - bob
+`)
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.DefaultProject != 42 {
+		t.Errorf("DefaultProject = %d, want 42", cfg.DefaultProject)
+	}
+	if cfg.DefaultOwner != "acme" {
+		t.Errorf("DefaultOwner = %q, want %q", cfg.DefaultOwner, "acme")
+	}
+	if len(cfg.Team) != 2 || cfg.Team[0] != "alice" {
+		t.Errorf("Team = %v, want [alice bob]", cfg.Team)
+	}
+}
+
+func TestLoad_ProfilesConfig(t *testing.T) {
+	setup(t)
+	writeConfig(t, `
+active-profile: work
+profiles:
+  work:
+    default-project: 10
+    default-owner: corp
+  personal:
+    default-project: 20
+    default-owner: me
+`)
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.DefaultProject != 10 {
+		t.Errorf("DefaultProject = %d, want 10", cfg.DefaultProject)
+	}
+	if cfg.DefaultOwner != "corp" {
+		t.Errorf("DefaultOwner = %q, want %q", cfg.DefaultOwner, "corp")
+	}
+}
+
+func TestLoad_ProfilesDefaultFallback(t *testing.T) {
+	setup(t)
+	writeConfig(t, `
+profiles:
+  default:
+    default-project: 99
+    default-owner: fallback
+`)
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.DefaultProject != 99 {
+		t.Errorf("DefaultProject = %d, want 99", cfg.DefaultProject)
+	}
+}
+
+func TestSave_Roundtrip(t *testing.T) {
+	setup(t)
+	original := &Config{
+		DefaultProject: 7,
+		DefaultOwner:   "test-org",
+		Team:           []string{"charlie"},
+	}
+	if err := Save(original); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if loaded.DefaultProject != original.DefaultProject {
+		t.Errorf("DefaultProject = %d, want %d", loaded.DefaultProject, original.DefaultProject)
+	}
+	if loaded.DefaultOwner != original.DefaultOwner {
+		t.Errorf("DefaultOwner = %q, want %q", loaded.DefaultOwner, original.DefaultOwner)
+	}
+	if len(loaded.Team) != 1 || loaded.Team[0] != "charlie" {
+		t.Errorf("Team = %v, want [charlie]", loaded.Team)
+	}
+}
+
+func TestSave_RoundtripWithProfiles(t *testing.T) {
+	setup(t)
+	writeConfig(t, `
+active-profile: dev
+profiles:
+  dev:
+    default-project: 1
+    default-owner: old
+`)
+	cfg := &Config{DefaultProject: 2, DefaultOwner: "new"}
+	if err := Save(cfg); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if loaded.DefaultOwner != "new" {
+		t.Errorf("DefaultOwner = %q, want %q", loaded.DefaultOwner, "new")
+	}
+}
+
+func TestUseProfile_CreatesAndMigratesLegacy(t *testing.T) {
+	setup(t)
+	// Start with a legacy config
+	writeConfig(t, `
+default-project: 5
+default-owner: legacy-org
+`)
+	if err := UseProfile("staging"); err != nil {
+		t.Fatalf("UseProfile() error: %v", err)
+	}
+	// The legacy config should be migrated to "default" profile
+	names, active, err := ListProfiles()
+	if err != nil {
+		t.Fatalf("ListProfiles() error: %v", err)
+	}
+	if active != "staging" {
+		t.Errorf("active = %q, want %q", active, "staging")
+	}
+	sort.Strings(names)
+	if len(names) != 2 {
+		t.Fatalf("expected 2 profiles, got %d: %v", len(names), names)
+	}
+	if names[0] != "default" || names[1] != "staging" {
+		t.Errorf("names = %v, want [default staging]", names)
+	}
+	// Verify legacy values migrated to "default" profile
+	if err := UseProfile("default"); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.DefaultProject != 5 || cfg.DefaultOwner != "legacy-org" {
+		t.Errorf("migrated default profile = %+v, want project=5 owner=legacy-org", cfg)
+	}
+}
+
+func TestUseProfile_SwitchesActive(t *testing.T) {
+	setup(t)
+	writeConfig(t, `
+active-profile: a
+profiles:
+  a:
+    default-owner: alpha
+  b:
+    default-owner: beta
+`)
+	if err := UseProfile("b"); err != nil {
+		t.Fatalf("UseProfile() error: %v", err)
+	}
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.DefaultOwner != "beta" {
+		t.Errorf("DefaultOwner = %q, want %q", cfg.DefaultOwner, "beta")
+	}
+}
+
+func TestDeleteProfile_ErrorsOnActive(t *testing.T) {
+	setup(t)
+	writeConfig(t, `
+active-profile: main
+profiles:
+  main:
+    default-owner: x
+  other:
+    default-owner: y
+`)
+	err := DeleteProfile("main")
+	if err == nil {
+		t.Fatal("expected error deleting active profile, got nil")
+	}
+}
+
+func TestDeleteProfile_RemovesInactive(t *testing.T) {
+	setup(t)
+	writeConfig(t, `
+active-profile: main
+profiles:
+  main:
+    default-owner: x
+  other:
+    default-owner: y
+`)
+	if err := DeleteProfile("other"); err != nil {
+		t.Fatalf("DeleteProfile() error: %v", err)
+	}
+	names, _, err := ListProfiles()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(names) != 1 || names[0] != "main" {
+		t.Errorf("profiles = %v, want [main]", names)
+	}
+}
+
+func TestDeleteProfile_NoProfiles(t *testing.T) {
+	setup(t)
+	err := DeleteProfile("anything")
+	if err == nil {
+		t.Fatal("expected error when no profiles, got nil")
+	}
+}
+
+func TestListProfiles_NoProfiles(t *testing.T) {
+	setup(t)
+	names, active, err := ListProfiles()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if names != nil || active != "" {
+		t.Errorf("expected nil names and empty active, got names=%v active=%q", names, active)
+	}
+}
+
+func TestListProfiles_ReturnsNamesAndActive(t *testing.T) {
+	setup(t)
+	writeConfig(t, `
+active-profile: second
+profiles:
+  first:
+    default-owner: a
+  second:
+    default-owner: b
+`)
+	names, active, err := ListProfiles()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if active != "second" {
+		t.Errorf("active = %q, want %q", active, "second")
+	}
+	sort.Strings(names)
+	if len(names) != 2 || names[0] != "first" || names[1] != "second" {
+		t.Errorf("names = %v, want [first second]", names)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -34,7 +34,14 @@ type State struct {
 	Logs     []LogEntry `json:"logs,omitempty"`
 }
 
+// dirOverride, when non-empty, replaces the default state directory.
+// Used by tests to redirect state I/O to a temp directory.
+var dirOverride string
+
 func path() (string, error) {
+	if dirOverride != "" {
+		return filepath.Join(dirOverride, "state.json"), nil
+	}
 	base, err := os.UserConfigDir()
 	if err != nil {
 		return "", err

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,0 +1,170 @@
+package state
+
+import (
+	"testing"
+	"time"
+)
+
+func setup(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	dirOverride = dir
+	t.Cleanup(func() { dirOverride = "" })
+}
+
+func TestLoad_NoFile(t *testing.T) {
+	setup(t)
+	st, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if len(st.Handoffs) != 0 || len(st.Logs) != 0 {
+		t.Errorf("expected empty state, got %+v", st)
+	}
+}
+
+func TestAddLog_AppendsEntries(t *testing.T) {
+	setup(t)
+	now := time.Now()
+	if err := AddLog(LogEntry{Issue: "org/repo#1", Time: now, Message: "first", Kind: "progress"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddLog(LogEntry{Issue: "org/repo#1", Time: now.Add(time.Minute), Message: "second", Kind: "decision"}); err != nil {
+		t.Fatal(err)
+	}
+	st, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(st.Logs) != 2 {
+		t.Fatalf("expected 2 logs, got %d", len(st.Logs))
+	}
+	if st.Logs[0].Message != "first" || st.Logs[1].Message != "second" {
+		t.Errorf("log messages = [%q, %q], want [first, second]", st.Logs[0].Message, st.Logs[1].Message)
+	}
+}
+
+func TestGetLogs_FiltersByIssue(t *testing.T) {
+	setup(t)
+	now := time.Now()
+	entries := []LogEntry{
+		{Issue: "org/repo#1", Time: now, Message: "a", Kind: "progress"},
+		{Issue: "org/repo#2", Time: now, Message: "b", Kind: "progress"},
+		{Issue: "org/repo#1", Time: now, Message: "c", Kind: "decision"},
+	}
+	for _, e := range entries {
+		if err := AddLog(e); err != nil {
+			t.Fatal(err)
+		}
+	}
+	logs, err := GetLogs("org/repo#1", time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(logs) != 2 {
+		t.Fatalf("expected 2 logs for issue #1, got %d", len(logs))
+	}
+	for _, l := range logs {
+		if l.Issue != "org/repo#1" {
+			t.Errorf("unexpected issue %q", l.Issue)
+		}
+	}
+}
+
+func TestGetLogs_FiltersBySince(t *testing.T) {
+	setup(t)
+	t0 := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC)
+	entries := []LogEntry{
+		{Issue: "x", Time: t0, Message: "old", Kind: "progress"},
+		{Issue: "x", Time: t1, Message: "mid", Kind: "progress"},
+		{Issue: "x", Time: t2, Message: "new", Kind: "progress"},
+	}
+	for _, e := range entries {
+		if err := AddLog(e); err != nil {
+			t.Fatal(err)
+		}
+	}
+	logs, err := GetLogs("", t1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(logs) != 2 {
+		t.Fatalf("expected 2 logs since t1, got %d", len(logs))
+	}
+	if logs[0].Message != "mid" || logs[1].Message != "new" {
+		t.Errorf("log messages = [%q, %q], want [mid, new]", logs[0].Message, logs[1].Message)
+	}
+}
+
+func TestGetLogs_BothFilters(t *testing.T) {
+	setup(t)
+	t0 := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
+	entries := []LogEntry{
+		{Issue: "a", Time: t0, Message: "a-old", Kind: "progress"},
+		{Issue: "a", Time: t1, Message: "a-new", Kind: "progress"},
+		{Issue: "b", Time: t1, Message: "b-new", Kind: "progress"},
+	}
+	for _, e := range entries {
+		if err := AddLog(e); err != nil {
+			t.Fatal(err)
+		}
+	}
+	logs, err := GetLogs("a", t1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(logs) != 1 || logs[0].Message != "a-new" {
+		t.Errorf("expected [a-new], got %v", logs)
+	}
+}
+
+func TestAddHandoff_AppendsHandoffs(t *testing.T) {
+	setup(t)
+	h1 := Handoff{Issue: "org/repo#1", Repo: "org/repo", Done: []string{"task1"}}
+	h2 := Handoff{Issue: "org/repo#2", Repo: "org/repo", Done: []string{"task2"}}
+	if err := AddHandoff(h1); err != nil {
+		t.Fatal(err)
+	}
+	if err := AddHandoff(h2); err != nil {
+		t.Fatal(err)
+	}
+	st, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(st.Handoffs) != 2 {
+		t.Fatalf("expected 2 handoffs, got %d", len(st.Handoffs))
+	}
+	if st.Handoffs[0].Issue != "org/repo#1" || st.Handoffs[1].Issue != "org/repo#2" {
+		t.Errorf("handoff issues = [%q, %q]", st.Handoffs[0].Issue, st.Handoffs[1].Issue)
+	}
+}
+
+func TestSave_Roundtrip(t *testing.T) {
+	setup(t)
+	now := time.Now().Truncate(time.Second)
+	original := &State{
+		LastSeen: now,
+		Logs:     []LogEntry{{Issue: "x", Time: now, Message: "test", Kind: "progress"}},
+		Handoffs: []Handoff{{Issue: "x", Repo: "r", Done: []string{"a"}}},
+	}
+	if err := Save(original); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !loaded.LastSeen.Equal(original.LastSeen) {
+		t.Errorf("LastSeen = %v, want %v", loaded.LastSeen, original.LastSeen)
+	}
+	if len(loaded.Logs) != 1 || loaded.Logs[0].Message != "test" {
+		t.Errorf("Logs = %+v", loaded.Logs)
+	}
+	if len(loaded.Handoffs) != 1 || loaded.Handoffs[0].Repo != "r" {
+		t.Errorf("Handoffs = %+v", loaded.Handoffs)
+	}
+}


### PR DESCRIPTION
Adds 30+ unit tests for config (profiles, legacy compat), state (logs, handoffs), and board (emoji padding, status ordering).

Closes #1