### PR TITLE
Add standalone board command

### DIFF
--- a/cmd/board_cmd.go
+++ b/cmd/board_cmd.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/maxbeizer/gh-planning/internal/config"
+	"github.com/maxbeizer/gh-planning/internal/github"
+	"github.com/maxbeizer/gh-planning/internal/output"
+	"github.com/spf13/cobra"
+)
+
+var boardOpts struct {
+	Project     int
+	Owner       string
+	Assignee    string
+	Stale       string
+	Exclude     []string
+	Swimlanes   bool
+	IncludeDone bool
+}
+
+// Default statuses to exclude when --include-done is not set.
+var defaultDoneStatuses = []string{"Done", "Completed", "Closed"}
+
+var boardCmd = &cobra.Command{
+	Use:   "board",
+	Short: "Show kanban board view of your project",
+	RunE:  runBoard,
+}
+
+func init() {
+	boardCmd.Flags().IntVar(&boardOpts.Project, "project", 0, "Project number")
+	boardCmd.Flags().StringVar(&boardOpts.Owner, "owner", "", "Project owner")
+	boardCmd.Flags().StringVar(&boardOpts.Assignee, "assignee", "", "Filter by assignee")
+	boardCmd.Flags().StringVar(&boardOpts.Stale, "stale", "", "Only show items stale for this duration")
+	boardCmd.Flags().StringSliceVar(&boardOpts.Exclude, "exclude", nil, "Exclude statuses (e.g. --exclude Done,Closed)")
+	boardCmd.Flags().BoolVar(&boardOpts.Swimlanes, "swimlanes", false, "Add assignee swimlanes to board view")
+	boardCmd.Flags().BoolVar(&boardOpts.IncludeDone, "include-done", false, "Include Done/Completed/Closed statuses (excluded by default)")
+}
+
+func runBoard(cmd *cobra.Command, args []string) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+	owner := boardOpts.Owner
+	project := boardOpts.Project
+	if owner == "" {
+		owner = cfg.DefaultOwner
+	}
+	if project == 0 {
+		project = cfg.DefaultProject
+	}
+	if owner == "" || project == 0 {
+		return fmt.Errorf("project owner and number are required (run `gh planning init`)")
+	}
+	staleDuration, err := parseDuration(boardOpts.Stale)
+	if err != nil {
+		return fmt.Errorf("invalid stale duration: %w", err)
+	}
+	projectData, err := github.GetProject(cmd.Context(), owner, project)
+	if err != nil {
+		return err
+	}
+
+	exclude := boardOpts.Exclude
+	if !boardOpts.IncludeDone && !cmd.Flags().Changed("exclude") {
+		exclude = defaultDoneStatuses
+	}
+
+	filtered := filterProjectItems(projectData, boardOpts.Assignee, staleDuration, exclude)
+
+	if OutputOptions().JSON || OutputOptions().JQ != "" {
+		payload := map[string]interface{}{
+			"title":  projectData.Title,
+			"owner":  owner,
+			"number": project,
+			"items":  filtered,
+		}
+		return output.PrintJSON(payload, OutputOptions())
+	}
+
+	fmt.Printf("📊 Project: %s (#%d)\n\n", projectData.Title, project)
+	if boardOpts.Swimlanes {
+		printSwimlaneBoardView(filtered)
+	} else {
+		printBoardView(filtered)
+	}
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,6 +34,7 @@ func init() {
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(configCmd)
 	rootCmd.AddCommand(statusCmd)
+	rootCmd.AddCommand(boardCmd)
 	rootCmd.AddCommand(trackCmd)
 	rootCmd.AddCommand(focusCmd)
 	rootCmd.AddCommand(unfocusCmd)


### PR DESCRIPTION
Adds `gh planning board` which excludes Done by default and is more discoverable than `status --board`.

Closes #4