### PR TITLE
Add dependency tracking and critical path

### DIFF
--- a/cmd/blocked.go
+++ b/cmd/blocked.go
@@ -1,0 +1,163 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/maxbeizer/gh-planning/internal/config"
+	"github.com/maxbeizer/gh-planning/internal/github"
+	"github.com/maxbeizer/gh-planning/internal/output"
+	"github.com/maxbeizer/gh-planning/internal/state"
+	"github.com/spf13/cobra"
+)
+
+var blockedOpts struct {
+	By      string
+	Repo    string
+	Owner   string
+	Project int
+}
+
+var blockedCmd = &cobra.Command{
+	Use:   "blocked <issue>",
+	Short: "Mark an issue as blocked by another issue",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runBlocked,
+}
+
+func init() {
+	blockedCmd.Flags().StringVar(&blockedOpts.By, "by", "", "Issue that is blocking (required)")
+	blockedCmd.Flags().StringVar(&blockedOpts.Repo, "repo", "", "Repository (owner/repo)")
+	blockedCmd.Flags().StringVar(&blockedOpts.Owner, "owner", "", "Project owner")
+	blockedCmd.Flags().IntVar(&blockedOpts.Project, "project", 0, "Project number")
+	_ = blockedCmd.MarkFlagRequired("by")
+}
+
+var unblockCmd = &cobra.Command{
+	Use:   "unblock <issue>",
+	Short: "Remove a block from an issue",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runUnblock,
+}
+
+func init() {
+	unblockCmd.Flags().StringVar(&blockedOpts.Repo, "repo", "", "Repository (owner/repo)")
+}
+
+func runBlocked(cmd *cobra.Command, args []string) error {
+	blockedRepo, blockedNumber, err := resolveIssueInput(args[0], blockedOpts.Repo)
+	if err != nil {
+		return fmt.Errorf("invalid blocked issue: %w", err)
+	}
+	byRepo, byNumber, err := resolveIssueInput(blockedOpts.By, blockedOpts.Repo)
+	if err != nil {
+		return fmt.Errorf("invalid --by issue: %w", err)
+	}
+
+	blockedRef := fmt.Sprintf("%s#%d", blockedRepo, blockedNumber)
+	byRef := fmt.Sprintf("%s#%d", byRepo, byNumber)
+
+	// Post comment on the blocked issue.
+	blockedOwner, blockedRepoName, err := splitRepo(blockedRepo)
+	if err != nil {
+		return err
+	}
+	comment := fmt.Sprintf("🚫 Blocked by #%d", byNumber)
+	if byRepo != blockedRepo {
+		comment = fmt.Sprintf("🚫 Blocked by %s#%d", byRepo, byNumber)
+	}
+	if err := github.CreateIssueComment(cmd.Context(), blockedOwner, blockedRepoName, blockedNumber, comment); err != nil {
+		return err
+	}
+
+	// Store dependency in local state.
+	now := time.Now()
+	if err := state.AddDependency(state.Dependency{
+		Blocked:   blockedRef,
+		BlockedBy: byRef,
+		Time:      now,
+	}); err != nil {
+		return err
+	}
+
+	// Optionally move to "Blocked" status.
+	trySetBlockedStatus(cmd, blockedRepo, blockedNumber)
+
+	if OutputOptions().JSON || OutputOptions().JQ != "" {
+		payload := map[string]interface{}{
+			"blocked":   blockedRef,
+			"blockedBy": byRef,
+			"comment":   comment,
+			"time":      now,
+		}
+		return output.PrintJSON(payload, OutputOptions())
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Marked %s as blocked by %s\n", blockedRef, byRef)
+	return nil
+}
+
+func runUnblock(cmd *cobra.Command, args []string) error {
+	repo, number, err := resolveIssueInput(args[0], blockedOpts.Repo)
+	if err != nil {
+		return fmt.Errorf("invalid issue: %w", err)
+	}
+	ref := fmt.Sprintf("%s#%d", repo, number)
+
+	// Post comment.
+	owner, repoName, err := splitRepo(repo)
+	if err != nil {
+		return err
+	}
+	comment := "✅ Unblocked"
+	if err := github.CreateIssueComment(cmd.Context(), owner, repoName, number, comment); err != nil {
+		return err
+	}
+
+	// Remove from local state.
+	if err := state.RemoveDependency(ref); err != nil {
+		return err
+	}
+
+	if OutputOptions().JSON || OutputOptions().JQ != "" {
+		payload := map[string]interface{}{
+			"unblocked": ref,
+			"comment":   comment,
+		}
+		return output.PrintJSON(payload, OutputOptions())
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Unblocked %s\n", ref)
+	return nil
+}
+
+// trySetBlockedStatus attempts to move the issue to "Blocked" status in the project.
+// It fails silently if the project or status is not configured.
+func trySetBlockedStatus(cmd *cobra.Command, repo string, number int) {
+	cfg, _ := config.Load()
+	owner := blockedOpts.Owner
+	project := blockedOpts.Project
+	if owner == "" {
+		owner = cfg.DefaultOwner
+	}
+	if project == 0 {
+		project = cfg.DefaultProject
+	}
+	if owner == "" || project == 0 {
+		return
+	}
+
+	projectID, _, statusFieldID, statusOptions, err := github.GetProjectInfo(cmd.Context(), owner, project)
+	if err != nil || statusFieldID == "" {
+		return
+	}
+	optionID, ok := findStatusOption(statusOptions, "Blocked")
+	if !ok {
+		return
+	}
+	itemID, err := findProjectItemID(cmd.Context(), owner, project, repo, number)
+	if err != nil {
+		return
+	}
+	_ = github.UpdateItemStatus(cmd.Context(), projectID, itemID, statusFieldID, optionID)
+}

--- a/cmd/critical_path.go
+++ b/cmd/critical_path.go
@@ -1,0 +1,241 @@
+package cmd
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/maxbeizer/gh-planning/internal/output"
+	"github.com/maxbeizer/gh-planning/internal/state"
+	"github.com/spf13/cobra"
+)
+
+var criticalPathCmd = &cobra.Command{
+	Use:   "critical-path",
+	Short: "Show the blocking chain and critical path",
+	RunE:  runCriticalPath,
+}
+
+func runCriticalPath(cmd *cobra.Command, args []string) error {
+	st, err := state.Load()
+	if err != nil {
+		return err
+	}
+	if len(st.Dependencies) == 0 {
+		if OutputOptions().JSON || OutputOptions().JQ != "" {
+			return output.PrintJSON(map[string]interface{}{
+				"criticalPath":  []string{},
+				"depth":         0,
+				"blocked":       []interface{}{},
+				"impactRanking": []interface{}{},
+			}, OutputOptions())
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), "No dependencies tracked.")
+		return nil
+	}
+
+	// Build adjacency: blocker -> list of issues it blocks.
+	blocks := map[string][]string{}    // blockerRef -> []blockedRef
+	blockedBy := map[string]string{}   // blockedRef -> blockerRef
+	allNodes := map[string]struct{}{}
+
+	for _, dep := range st.Dependencies {
+		blocks[dep.BlockedBy] = append(blocks[dep.BlockedBy], dep.Blocked)
+		blockedBy[dep.Blocked] = dep.BlockedBy
+		allNodes[dep.Blocked] = struct{}{}
+		allNodes[dep.BlockedBy] = struct{}{}
+	}
+
+	// Find roots: nodes that block others but are not themselves blocked.
+	roots := []string{}
+	for node := range allNodes {
+		if _, isBlocked := blockedBy[node]; !isBlocked {
+			if _, doesBlock := blocks[node]; doesBlock {
+				roots = append(roots, node)
+			}
+		}
+	}
+	sort.Strings(roots)
+
+	// Build all chains from each root using DFS.
+	type chain struct {
+		path []string
+	}
+	var allChains []chain
+	var dfs func(node string, current []string, visited map[string]bool)
+	dfs = func(node string, current []string, visited map[string]bool) {
+		current = append(current, node)
+		children := blocks[node]
+		if len(children) == 0 {
+			ch := make([]string, len(current))
+			copy(ch, current)
+			allChains = append(allChains, chain{path: ch})
+			return
+		}
+		sort.Strings(children)
+		for _, child := range children {
+			if visited[child] {
+				continue
+			}
+			visited[child] = true
+			dfs(child, current, visited)
+			visited[child] = false
+		}
+	}
+
+	for _, root := range roots {
+		visited := map[string]bool{root: true}
+		dfs(root, nil, visited)
+	}
+
+	// Find the longest chain (critical path).
+	var critical []string
+	for _, ch := range allChains {
+		if len(ch.path) > len(critical) {
+			critical = ch.path
+		}
+	}
+
+	// Compute impact: how many issues each blocker transitively blocks.
+	impact := map[string]int{}
+	var countBlocked func(node string) int
+	countBlocked = func(node string) int {
+		total := 0
+		for _, child := range blocks[node] {
+			total += 1 + countBlocked(child)
+		}
+		impact[node] = total
+		return total
+	}
+	for _, root := range roots {
+		countBlocked(root)
+	}
+
+	// Build impact ranking (nodes that unblocking would help the most).
+	type impactEntry struct {
+		Issue string `json:"issue"`
+		Count int    `json:"unblocks"`
+	}
+	var ranking []impactEntry
+	for issue, count := range impact {
+		if count > 0 {
+			ranking = append(ranking, impactEntry{Issue: issue, Count: count})
+		}
+	}
+	sort.Slice(ranking, func(i, j int) bool {
+		if ranking[i].Count != ranking[j].Count {
+			return ranking[i].Count > ranking[j].Count
+		}
+		return ranking[i].Issue < ranking[j].Issue
+	})
+
+	if OutputOptions().JSON || OutputOptions().JQ != "" {
+		payload := map[string]interface{}{
+			"criticalPath":  critical,
+			"depth":         len(critical),
+			"dependencies":  st.Dependencies,
+			"impactRanking": ranking,
+		}
+		return output.PrintJSON(payload, OutputOptions())
+	}
+
+	// Render critical path.
+	fmt.Fprintf(cmd.OutOrStdout(), "🔴 Critical Path (%d deep):\n", len(critical))
+	for i, node := range critical {
+		indent := strings.Repeat("    ", i)
+		num := issueNumber(node)
+		if i == 0 {
+			fmt.Fprintf(cmd.OutOrStdout(), "%s%s\n", indent, num)
+		} else {
+			fmt.Fprintf(cmd.OutOrStdout(), "%s└── blocks %s\n", indent, num)
+		}
+	}
+
+	// Render other blocked items (chains not on the critical path).
+	criticalSet := map[string]bool{}
+	for _, n := range critical {
+		criticalSet[n] = true
+	}
+
+	otherRoots := []string{}
+	for _, root := range roots {
+		if !criticalSet[root] {
+			otherRoots = append(otherRoots, root)
+		}
+	}
+
+	// Also show non-critical chains from critical roots.
+	hasOther := len(otherRoots) > 0
+	for _, dep := range st.Dependencies {
+		if !criticalSet[dep.Blocked] || !criticalSet[dep.BlockedBy] {
+			hasOther = true
+			break
+		}
+	}
+
+	if hasOther {
+		fmt.Fprintf(cmd.OutOrStdout(), "\n🟡 Other blocked items:\n")
+		printed := map[string]bool{}
+		var printTree func(node string, depth int)
+		printTree = func(node string, depth int) {
+			children := blocks[node]
+			sort.Strings(children)
+			for _, child := range children {
+				if printed[child] {
+					continue
+				}
+				printed[child] = true
+				indent := strings.Repeat("    ", depth)
+				num := issueNumber(child)
+				blockerNum := issueNumber(node)
+				if depth == 0 {
+					fmt.Fprintf(cmd.OutOrStdout(), "%s\n", num)
+					fmt.Fprintf(cmd.OutOrStdout(), "└── blocked by %s\n", blockerNum)
+				} else {
+					fmt.Fprintf(cmd.OutOrStdout(), "%s└── blocked by %s\n", indent, blockerNum)
+				}
+				printTree(child, depth+1)
+			}
+		}
+		for _, root := range otherRoots {
+			num := issueNumber(root)
+			fmt.Fprintf(cmd.OutOrStdout(), "%s\n", num)
+			printTree(root, 0)
+		}
+		// Print non-critical branches from critical roots.
+		for _, root := range roots {
+			if criticalSet[root] {
+				children := blocks[root]
+				for _, child := range children {
+					if !criticalSet[child] && !printed[child] {
+						printed[child] = true
+						num := issueNumber(child)
+						blockerNum := issueNumber(root)
+						fmt.Fprintf(cmd.OutOrStdout(), "%s\n", num)
+						fmt.Fprintf(cmd.OutOrStdout(), "└── blocked by %s\n", blockerNum)
+						printTree(child, 1)
+					}
+				}
+			}
+		}
+	}
+
+	// Impact ranking.
+	if len(ranking) > 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "\n⚡ Unblocking impact:\n")
+		for _, entry := range ranking {
+			num := issueNumber(entry.Issue)
+			fmt.Fprintf(cmd.OutOrStdout(), "  %s → would unblock %d issue(s)\n", num, entry.Count)
+		}
+	}
+
+	return nil
+}
+
+// issueNumber extracts "#N" from "owner/repo#N", or returns the ref as-is.
+func issueNumber(ref string) string {
+	if idx := strings.LastIndex(ref, "#"); idx >= 0 {
+		return "#" + ref[idx+1:]
+	}
+	return ref
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,6 +54,9 @@ func init() {
 	rootCmd.AddCommand(setupCmd)
 	rootCmd.AddCommand(logCmd)
 	rootCmd.AddCommand(logsCmd)
+	rootCmd.AddCommand(blockedCmd)
+	rootCmd.AddCommand(unblockCmd)
+	rootCmd.AddCommand(criticalPathCmd)
 }
 
 func runRoot(cmd *cobra.Command, args []string) error {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -28,10 +28,17 @@ type LogEntry struct {
 	Kind      string    `json:"kind"` // progress, decision, blocker, hypothesis, tried, result
 }
 
+type Dependency struct {
+	Blocked   string    `json:"blocked"`   // owner/repo#number
+	BlockedBy string    `json:"blockedBy"` // owner/repo#number
+	Time      time.Time `json:"time"`
+}
+
 type State struct {
-	LastSeen time.Time  `json:"lastSeen,omitempty"`
-	Handoffs []Handoff  `json:"handoffs,omitempty"`
-	Logs     []LogEntry `json:"logs,omitempty"`
+	LastSeen     time.Time    `json:"lastSeen,omitempty"`
+	Handoffs     []Handoff    `json:"handoffs,omitempty"`
+	Logs         []LogEntry   `json:"logs,omitempty"`
+	Dependencies []Dependency `json:"dependencies,omitempty"`
 }
 
 // dirOverride, when non-empty, replaces the default state directory.
@@ -107,6 +114,36 @@ func AddLog(entry LogEntry) error {
 		return err
 	}
 	st.Logs = append(st.Logs, entry)
+	return Save(st)
+}
+
+func AddDependency(dep Dependency) error {
+	st, err := Load()
+	if err != nil {
+		return err
+	}
+	// Avoid duplicates.
+	for _, d := range st.Dependencies {
+		if d.Blocked == dep.Blocked && d.BlockedBy == dep.BlockedBy {
+			return nil
+		}
+	}
+	st.Dependencies = append(st.Dependencies, dep)
+	return Save(st)
+}
+
+func RemoveDependency(blocked string) error {
+	st, err := Load()
+	if err != nil {
+		return err
+	}
+	filtered := st.Dependencies[:0]
+	for _, d := range st.Dependencies {
+		if d.Blocked != blocked {
+			filtered = append(filtered, d)
+		}
+	}
+	st.Dependencies = filtered
 	return Save(st)
 }
 


### PR DESCRIPTION
`blocked`/`unblock` commands for marking dependencies, `critical-path` for DAG analysis showing the longest blocking chain and impact ranking.

Closes #15