### PR TITLE
fix: remove unsupported --owner/--project flags from critical-path MCP tool

### DIFF
--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -495,16 +495,10 @@ var tools = []ToolDefinition{
 	{
 		Name:        "planning-criticalPath",
 		Description: "Show the critical path through blocked dependencies",
-		InputSchema: objectSchema(map[string]interface{}{
-			"project": intSchema("Project number"),
-			"owner":   stringSchema("Project owner"),
-		}),
-		Command: []string{"planning", "critical-path"},
+		InputSchema: objectSchema(map[string]interface{}{}),
+		Command:     []string{"planning", "critical-path"},
 		Build: func(args map[string]interface{}) ([]string, error) {
-			return buildFlags([]string{"planning", "critical-path"}, args, flagSpec{
-				"project": flagInt("--project"),
-				"owner":   flagString("--owner"),
-			})
+			return []string{"planning", "critical-path"}, nil
 		},
 	},
 	{


### PR DESCRIPTION
## Summary

The MCP tool definition for `planning-criticalPath` advertised `owner` and `project` parameters that the cobra command doesn't accept. When an MCP client passed these parameters, it failed with `Error: unknown flag: --owner`.

## Fix

Removed the bogus parameters from the MCP tool definition and simplified the `Build` function, since `critical-path` is a state-only command that reads from `state.Load()`.

Closes #31