### PR TITLE
fix: remove unsupported --json flag from gh issue create

### DIFF
--- a/cmd/track.go
+++ b/cmd/track.go
@@ -55,7 +55,7 @@ func runTrack(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--repo is required when not in a git repository")
 	}
 	title := args[0]
-	argsCreate := []string{"issue", "create", "--repo", trackOpts.Repo, "--title", title, "--json", "id,number,url,repository"}
+	argsCreate := []string{"issue", "create", "--repo", trackOpts.Repo, "--title", title}
 	if trackOpts.Body != "" {
 		argsCreate = append(argsCreate, "--body", trackOpts.Body)
 	}
@@ -68,7 +68,14 @@ func runTrack(cmd *cobra.Command, args []string) error {
 	if trackOpts.Assignee != "" {
 		argsCreate = append(argsCreate, "--assignee", trackOpts.Assignee)
 	}
-	issuePayload, err := github.Run(cmd.Context(), argsCreate...)
+	createOut, err := github.Run(cmd.Context(), argsCreate...)
+	if err != nil {
+		return err
+	}
+	issueURL := strings.TrimSpace(string(createOut))
+
+	// gh issue create only returns the URL; fetch structured data with gh issue view
+	issuePayload, err := github.Run(cmd.Context(), "issue", "view", issueURL, "--json", "id,number,url,repository")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Problem

`planning track` fails because it passes `--json id,number,url,repository` to `gh issue create`, which does not support the `--json` flag.

## Fix

1. Remove `--json` from the `gh issue create` invocation
2. Parse the issue URL from stdout (the default output of `gh issue create`)
3. Use `gh issue view <url> --json ...` to fetch structured data

Closes #49