### PR TITLE
refactor: code health improvements across codebase

### DIFF
--- a/cmd/blocked.go
+++ b/cmd/blocked.go
@@ -90,7 +90,7 @@ func runBlocked(cmd *cobra.Command, args []string) error {
 			"comment":   comment,
 			"time":      now,
 		}
-		return output.PrintJSON(payload, OutputOptions())
+		return output.PrintJSON(cmd.OutOrStdout(), payload, OutputOptions())
 	}
 
 	fmt.Fprintf(cmd.OutOrStdout(), "Marked %s as blocked by %s\n", blockedRef, byRef)
@@ -124,7 +124,7 @@ func runUnblock(cmd *cobra.Command, args []string) error {
 			"unblocked": ref,
 			"comment":   comment,
 		}
-		return output.PrintJSON(payload, OutputOptions())
+		return output.PrintJSON(cmd.OutOrStdout(), payload, OutputOptions())
 	}
 
 	fmt.Fprintf(cmd.OutOrStdout(), "Unblocked %s\n", ref)

--- a/cmd/board.go
+++ b/cmd/board.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"sort"
 	"strings"
@@ -71,10 +72,10 @@ func statusEmoji(status string) string {
 }
 
 // printBoardView renders a kanban board with columns per status.
-func printBoardView(groups map[string][]github.ProjectItem) {
+func printBoardView(w io.Writer, groups map[string][]github.ProjectItem) {
 	statuses := sortedStatuses(groups)
 	if len(statuses) == 0 {
-		fmt.Println("  (no items)")
+		fmt.Fprintln(w, "  (no items)")
 		return
 	}
 
@@ -142,21 +143,21 @@ func printBoardView(groups map[string][]github.ProjectItem) {
 	for i := range topParts {
 		topParts[i] = strings.Repeat("─", innerWidth+2)
 	}
-	fmt.Printf("┌%s┐\n", strings.Join(topParts, "┬"))
+	fmt.Fprintf(w, "┌%s┐\n", strings.Join(topParts, "┬"))
 
 	// Header row
 	headerParts := make([]string, numCols)
 	for col := range columns {
 		headerParts[col] = " " + columns[col][0] + " "
 	}
-	fmt.Printf("│%s│\n", strings.Join(headerParts, "│"))
+	fmt.Fprintf(w, "│%s│\n", strings.Join(headerParts, "│"))
 
 	// Header separator
 	sepParts := make([]string, numCols)
 	for i := range sepParts {
 		sepParts[i] = strings.Repeat("─", innerWidth+2)
 	}
-	fmt.Printf("├%s┤\n", strings.Join(sepParts, "┼"))
+	fmt.Fprintf(w, "├%s┤\n", strings.Join(sepParts, "┼"))
 
 	// Card rows (skip row 0, that was the header)
 	for row := 1; row < maxRows; row++ {
@@ -168,7 +169,7 @@ func printBoardView(groups map[string][]github.ProjectItem) {
 				parts[col] = " " + strings.Repeat(" ", innerWidth) + " "
 			}
 		}
-		fmt.Printf("│%s│\n", strings.Join(parts, "│"))
+		fmt.Fprintf(w, "│%s│\n", strings.Join(parts, "│"))
 	}
 
 	// Bottom border
@@ -176,14 +177,14 @@ func printBoardView(groups map[string][]github.ProjectItem) {
 	for i := range bottomParts {
 		bottomParts[i] = strings.Repeat("─", innerWidth+2)
 	}
-	fmt.Printf("└%s┘\n", strings.Join(bottomParts, "┴"))
+	fmt.Fprintf(w, "└%s┘\n", strings.Join(bottomParts, "┴"))
 }
 
 // printSwimlaneBoardView renders a kanban board with swimlanes per assignee.
-func printSwimlaneBoardView(groups map[string][]github.ProjectItem) {
+func printSwimlaneBoardView(w io.Writer, groups map[string][]github.ProjectItem) {
 	statuses := sortedStatuses(groups)
 	if len(statuses) == 0 {
-		fmt.Println("  (no items)")
+		fmt.Fprintln(w, "  (no items)")
 		return
 	}
 
@@ -229,20 +230,20 @@ func printSwimlaneBoardView(groups map[string][]github.ProjectItem) {
 	for i := range topParts {
 		topParts[i] = strings.Repeat("─", innerWidth+2)
 	}
-	fmt.Printf("┌%s┐\n", strings.Join(topParts, "┬"))
+	fmt.Fprintf(w, "┌%s┐\n", strings.Join(topParts, "┬"))
 
 	headerParts := make([]string, numCols)
 	for i, status := range statuses {
 		header := fmt.Sprintf("%s %s (%d)", statusEmoji(status), status, len(groups[status]))
 		headerParts[i] = " " + padOrTruncate(header, innerWidth) + " "
 	}
-	fmt.Printf("│%s│\n", strings.Join(headerParts, "│"))
+	fmt.Fprintf(w, "│%s│\n", strings.Join(headerParts, "│"))
 
 	sepParts := make([]string, numCols)
 	for i := range sepParts {
 		sepParts[i] = strings.Repeat("═", innerWidth+2)
 	}
-	fmt.Printf("╞%s╡\n", strings.Join(sepParts, "╪"))
+	fmt.Fprintf(w, "╞%s╡\n", strings.Join(sepParts, "╪"))
 
 	// Print each swimlane
 	for laneIdx, assignee := range assignees {
@@ -259,7 +260,7 @@ func printSwimlaneBoardView(groups map[string][]github.ProjectItem) {
 				laneLine[i] = " " + strings.Repeat(" ", innerWidth) + " "
 			}
 		}
-		fmt.Printf("│%s│\n", strings.Join(laneLine, "│"))
+		fmt.Fprintf(w, "│%s│\n", strings.Join(laneLine, "│"))
 
 		// Items for this assignee in each column
 		columns := make([][]string, numCols)
@@ -315,7 +316,7 @@ func printSwimlaneBoardView(groups map[string][]github.ProjectItem) {
 					parts[col] = " " + strings.Repeat(" ", innerWidth) + " "
 				}
 			}
-			fmt.Printf("│%s│\n", strings.Join(parts, "│"))
+			fmt.Fprintf(w, "│%s│\n", strings.Join(parts, "│"))
 		}
 
 		// Separator between swimlanes (not after last)
@@ -324,7 +325,7 @@ func printSwimlaneBoardView(groups map[string][]github.ProjectItem) {
 			for i := range divParts {
 				divParts[i] = strings.Repeat("─", innerWidth+2)
 			}
-			fmt.Printf("├%s┤\n", strings.Join(divParts, "┼"))
+			fmt.Fprintf(w, "├%s┤\n", strings.Join(divParts, "┼"))
 		}
 	}
 
@@ -333,7 +334,7 @@ func printSwimlaneBoardView(groups map[string][]github.ProjectItem) {
 	for i := range bottomParts {
 		bottomParts[i] = strings.Repeat("─", innerWidth+2)
 	}
-	fmt.Printf("└%s┘\n", strings.Join(bottomParts, "┴"))
+	fmt.Fprintf(w, "└%s┘\n", strings.Join(bottomParts, "┴"))
 }
 
 func padOrTruncate(s string, width int) string {

--- a/cmd/board_cmd.go
+++ b/cmd/board_cmd.go
@@ -74,16 +74,16 @@ func runBoard(cmd *cobra.Command, args []string) error {
 			"number": pc.Project,
 			"items":  filtered,
 		}
-		return output.PrintJSON(payload, OutputOptions())
+		return output.PrintJSON(cmd.OutOrStdout(), payload, OutputOptions())
 	}
 
 	fmt.Fprintf(cmd.OutOrStdout(), "📊 Project: %s (#%d)\n", projectData.Title, pc.Project)
 	fmt.Fprintf(cmd.OutOrStdout(), "   %s\n\n", projectURL(pc.Owner, pc.Project))
 
 	if boardOpts.Swimlanes {
-		printSwimlaneBoardView(filtered)
+		printSwimlaneBoardView(cmd.OutOrStdout(), filtered)
 	} else {
-		printBoardView(filtered)
+		printBoardView(cmd.OutOrStdout(), filtered)
 	}
 	return nil
 }

--- a/cmd/catchup.go
+++ b/cmd/catchup.go
@@ -180,7 +180,7 @@ func runCatchup(cmd *cobra.Command, args []string) error {
 			"label":    label,
 			"sections": sections,
 		}
-		return output.PrintJSON(payload, OutputOptions())
+		return output.PrintJSON(cmd.OutOrStdout(), payload, OutputOptions())
 	}
 
 	fmt.Fprintf(cmd.OutOrStdout(), "📬 Catch-up — since %s\n\n", label)

--- a/cmd/copilot.go
+++ b/cmd/copilot.go
@@ -34,7 +34,7 @@ var copilotSkillsCmd = &cobra.Command{
 			return err
 		}
 		if OutputOptions().JSON || OutputOptions().JQ != "" {
-			return output.PrintJSON(map[string]interface{}{"skills": skills}, OutputOptions())
+			return output.PrintJSON(cmd.OutOrStdout(), map[string]interface{}{"skills": skills}, OutputOptions())
 		}
 		for _, skill := range skills {
 			fmt.Fprintln(cmd.OutOrStdout(), skill)
@@ -57,7 +57,7 @@ var copilotTestCmd = &cobra.Command{
 			"reason":  suggestion.Reason,
 		}
 		if OutputOptions().JSON || OutputOptions().JQ != "" {
-			return output.PrintJSON(payload, OutputOptions())
+			return output.PrintJSON(cmd.OutOrStdout(), payload, OutputOptions())
 		}
 		fmt.Fprintf(cmd.OutOrStdout(), "Skill: %s\n", suggestion.Skill)
 		fmt.Fprintf(cmd.OutOrStdout(), "Command: %s\n", suggestion.Command)

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -211,3 +211,16 @@ return item.ID, nil
 }
 return "", fmt.Errorf("issue not found in project")
 }
+
+// splitAndTrim splits a comma-separated string and trims whitespace.
+func splitAndTrim(value string) []string {
+	parts := strings.Split(value, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			result = append(result, p)
+		}
+	}
+	return result
+}

--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -1,6 +1,12 @@
 package cmd
 
-import "testing"
+import (
+	"testing"
+	"time"
+
+	"github.com/mattn/go-runewidth"
+	"github.com/maxbeizer/gh-planning/internal/github"
+)
 
 func TestResolveIssueInput_URL(t *testing.T) {
 	repo, num, err := resolveIssueInput("https://github.com/maxbeizer/app/issues/42", "")
@@ -179,4 +185,210 @@ func TestSplitAndTrim(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestParseDuration(t *testing.T) {
+	tests := []struct {
+		input string
+		want  time.Duration
+		err   bool
+	}{
+		{"", 0, false},
+		{"1h", time.Hour, false},
+		{"30m", 30 * time.Minute, false},
+		{"2d", 48 * time.Hour, false},
+		{"7d", 7 * 24 * time.Hour, false},
+		{"1s", time.Second, false},
+		{"abc", 0, true},
+		{"xd", 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := parseDuration(tt.input)
+			if tt.err && err == nil {
+				t.Fatalf("parseDuration(%q) expected error, got nil", tt.input)
+			}
+			if !tt.err && err != nil {
+				t.Fatalf("parseDuration(%q) unexpected error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("parseDuration(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHumanizeDuration(t *testing.T) {
+	tests := []struct {
+		input time.Duration
+		want  string
+	}{
+		{5 * time.Minute, "5m ago"},
+		{30 * time.Minute, "30m ago"},
+		{2 * time.Hour, "2h ago"},
+		{23 * time.Hour, "23h ago"},
+		{48 * time.Hour, "2d ago"},
+		{6 * 24 * time.Hour, "6d ago"},
+		{14 * 24 * time.Hour, "2w ago"},
+		{-5 * time.Minute, "5m ago"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := humanizeDuration(tt.input)
+			if got != tt.want {
+				t.Errorf("humanizeDuration(%v) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProjectURL(t *testing.T) {
+	got := projectURL("maxbeizer", 42)
+	want := "https://github.com/users/maxbeizer/projects/42"
+	if got != want {
+		t.Errorf("projectURL() = %q, want %q", got, want)
+	}
+}
+
+func TestFilterProjectItems(t *testing.T) {
+	now := time.Now()
+	project := &github.Project{
+		Items: map[string][]github.ProjectItem{
+			"In Progress": {
+				{Number: 1, Title: "Task 1", Assignees: []string{"alice"}, UpdatedAt: now},
+				{Number: 2, Title: "Task 2", Assignees: []string{"bob"}, UpdatedAt: now.Add(-48 * time.Hour)},
+			},
+			"Done": {
+				{Number: 3, Title: "Task 3", Assignees: []string{"alice"}, UpdatedAt: now},
+			},
+		},
+	}
+
+	t.Run("no filters", func(t *testing.T) {
+		result := filterProjectItems(project, "", 0, nil)
+		total := 0
+		for _, items := range result {
+			total += len(items)
+		}
+		if total != 3 {
+			t.Errorf("expected 3 items, got %d", total)
+		}
+	})
+
+	t.Run("filter by assignee", func(t *testing.T) {
+		result := filterProjectItems(project, "alice", 0, nil)
+		total := 0
+		for _, items := range result {
+			total += len(items)
+		}
+		if total != 2 {
+			t.Errorf("expected 2 items for alice, got %d", total)
+		}
+	})
+
+	t.Run("exclude status", func(t *testing.T) {
+		result := filterProjectItems(project, "", 0, []string{"Done"})
+		if _, ok := result["Done"]; ok {
+			t.Error("expected Done to be excluded")
+		}
+		if len(result["In Progress"]) != 2 {
+			t.Errorf("expected 2 In Progress items, got %d", len(result["In Progress"]))
+		}
+	})
+
+	t.Run("stale filter", func(t *testing.T) {
+		result := filterProjectItems(project, "", 24*time.Hour, nil)
+		total := 0
+		for _, items := range result {
+			total += len(items)
+		}
+		if total != 1 {
+			t.Errorf("expected 1 stale item, got %d", total)
+		}
+	})
+}
+
+func TestDecorateStatus(t *testing.T) {
+	tests := []struct {
+		status string
+		prefix string
+	}{
+		{"In Progress", "🔵"},
+		{"Backlog", "📋"},
+		{"Done", "✅"},
+		{"Closed", "✅"},
+		{"In Review", "🔍"},
+		{"Needs Review", "🔍"},
+		{"Something Else", "•"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			got := decorateStatus(tt.status, tt.status)
+			if got[:len(tt.prefix)] != tt.prefix {
+				t.Errorf("decorateStatus(%q) = %q, want prefix %q", tt.status, got, tt.prefix)
+			}
+		})
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		max   int
+		fits  bool
+	}{
+		{"short string", "hello", 10, true},
+		{"exact fit", "hello", 5, true},
+		{"needs truncation", "hello world this is long", 10, false},
+		{"emoji string", "🔵 In Progress", 10, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := truncate(tt.input, tt.max)
+			width := runewidth.StringWidth(result)
+			if width > tt.max {
+				t.Errorf("truncate(%q, %d) visual width = %d, exceeds max", tt.input, tt.max, width)
+			}
+			if tt.fits && result != tt.input {
+				t.Errorf("truncate(%q, %d) = %q, expected unchanged", tt.input, tt.max, result)
+			}
+		})
+	}
+}
+
+func TestFindStatusOption(t *testing.T) {
+	options := map[string]string{
+		"In Progress": "opt-1",
+		"Done":        "opt-2",
+		"Backlog":     "opt-3",
+	}
+
+	t.Run("exact match", func(t *testing.T) {
+		id, ok := findStatusOption(options, "Done")
+		if !ok || id != "opt-2" {
+			t.Errorf("expected opt-2, got %q (ok=%v)", id, ok)
+		}
+	})
+
+	t.Run("case insensitive", func(t *testing.T) {
+		id, ok := findStatusOption(options, "done")
+		if !ok || id != "opt-2" {
+			t.Errorf("expected opt-2 (case insensitive), got %q (ok=%v)", id, ok)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, ok := findStatusOption(options, "Nonexistent")
+		if ok {
+			t.Error("expected not found")
+		}
+	})
+
+	t.Run("multiple names fallback", func(t *testing.T) {
+		id, ok := findStatusOption(options, "Nonexistent", "Backlog")
+		if !ok || id != "opt-3" {
+			t.Errorf("expected opt-3 (fallback), got %q (ok=%v)", id, ok)
+		}
+	})
 }

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -87,7 +87,7 @@ func runLog(cmd *cobra.Command, args []string) error {
 	}
 
 	if OutputOptions().JSON || OutputOptions().JQ != "" {
-		return output.PrintJSON(entry, OutputOptions())
+		return output.PrintJSON(cmd.OutOrStdout(), entry, OutputOptions())
 	}
 
 	fmt.Fprintf(cmd.OutOrStdout(), "%s [%s] %s (%s)\n", prefix, kind, message, focus.Issue)
@@ -139,7 +139,7 @@ func runLogs(cmd *cobra.Command, args []string) error {
 	}
 
 	if OutputOptions().JSON || OutputOptions().JQ != "" {
-		return output.PrintJSON(entries, OutputOptions())
+		return output.PrintJSON(cmd.OutOrStdout(), entries, OutputOptions())
 	}
 
 	if len(entries) == 0 {

--- a/cmd/prep.go
+++ b/cmd/prep.go
@@ -117,7 +117,7 @@ func runPrep(cmd *cobra.Command, args []string) error {
 	}
 
 	if OutputOptions().JSON || OutputOptions().JQ != "" {
-		return output.PrintJSON(report, OutputOptions())
+		return output.PrintJSON(cmd.OutOrStdout(), report, OutputOptions())
 	}
 
 	prepDoc := renderPrepDoc(report)

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -217,7 +217,7 @@ func runProfileShow(cmd *cobra.Command, args []string) error {
 		if detected != "" {
 			payload["detected"] = detected
 		}
-		return output.PrintJSON(payload, OutputOptions())
+		return output.PrintJSON(cmd.OutOrStdout(), payload, OutputOptions())
 	}
 
 	if detected != "" && detected != profileName {
@@ -269,7 +269,7 @@ func runProfileList(cmd *cobra.Command, args []string) error {
 		if detected != "" {
 			payload["detected"] = detected
 		}
-		return output.PrintJSON(payload, OutputOptions())
+		return output.PrintJSON(cmd.OutOrStdout(), payload, OutputOptions())
 	}
 
 	for _, name := range names {
@@ -491,7 +491,7 @@ func runProfileUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	if OutputOptions().JSON || OutputOptions().JQ != "" {
-		return output.PrintJSON(map[string]interface{}{
+		return output.PrintJSON(cmd.OutOrStdout(), map[string]interface{}{
 			"profile": name,
 			"updated": true,
 			"config":  cfg,
@@ -528,7 +528,7 @@ func runProfileDetect(cmd *cobra.Command, args []string) error {
 		for i, m := range matches {
 			names[i] = m.Name
 		}
-		return output.PrintJSON(map[string]interface{}{"matches": names}, OutputOptions())
+		return output.PrintJSON(cmd.OutOrStdout(), map[string]interface{}{"matches": names}, OutputOptions())
 	}
 
 	if len(matches) == 0 {
@@ -544,7 +544,7 @@ func runProfileDetect(cmd *cobra.Command, args []string) error {
 			}
 
 			if OutputOptions().JSON || OutputOptions().JQ != "" {
-				return output.PrintJSON(map[string]interface{}{
+				return output.PrintJSON(cmd.OutOrStdout(), map[string]interface{}{
 					"matches":    []string{},
 					"helmDetect": true,
 					"project":    helmCfg.Project.Board,
@@ -684,15 +684,4 @@ func (m profileSelectModel) View() string {
 	return b.String()
 }
 
-// splitAndTrim splits a comma-separated string and trims whitespace.
-func splitAndTrim(value string) []string {
-	parts := strings.Split(value, ",")
-	result := make([]string, 0, len(parts))
-	for _, p := range parts {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			result = append(result, p)
-		}
-	}
-	return result
-}
+

--- a/cmd/pulse.go
+++ b/cmd/pulse.go
@@ -53,7 +53,7 @@ func runPulse(cmd *cobra.Command, args []string) error {
 	}
 	users := []string{}
 	if pulseOpts.Team != "" {
-		users = splitTeam(pulseOpts.Team)
+		users = splitAndTrim(pulseOpts.Team)
 	} else {
 		users = append(users, cfg.Team...)
 	}
@@ -125,7 +125,7 @@ func runPulse(cmd *cobra.Command, args []string) error {
 			"summary":  summary,
 			"duration": sinceDuration.String(),
 		}
-		return output.PrintJSON(payload, OutputOptions())
+		return output.PrintJSON(cmd.OutOrStdout(), payload, OutputOptions())
 	}
 
 	w := cmd.OutOrStdout()

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -103,7 +103,7 @@ func runReview(cmd *cobra.Command, args []string) error {
 			"details": pr,
 			"summary": summary,
 		}
-		return output.PrintJSON(payload, OutputOptions())
+		return output.PrintJSON(cmd.OutOrStdout(), payload, OutputOptions())
 	}
 
 	w := cmd.OutOrStdout()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -77,7 +77,7 @@ func runRoot(cmd *cobra.Command, args []string) error {
 			"focus":         focus,
 			"statusSummary": statusSummary,
 		}
-		return output.PrintJSON(payload, rootOpts)
+		return output.PrintJSON(cmd.OutOrStdout(), payload, rootOpts)
 	}
 
 	fmt.Fprintln(cmd.OutOrStdout(), "gh-planning — developer command center")

--- a/cmd/standup.go
+++ b/cmd/standup.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 	"time"
@@ -100,7 +101,7 @@ func runStandup(cmd *cobra.Command, args []string) error {
 			"team":      standupOpts.Team,
 			"reports":   results,
 		}
-		return output.PrintJSON(payload, OutputOptions())
+		return output.PrintJSON(cmd.OutOrStdout(), payload, OutputOptions())
 	}
 
 	fmt.Fprintf(cmd.OutOrStdout(), "📋 Standup — %s\n\n", time.Now().Format("Mon Jan 2, 2006"))
@@ -108,7 +109,7 @@ func runStandup(cmd *cobra.Command, args []string) error {
 		if standupOpts.Team {
 			fmt.Fprintf(cmd.OutOrStdout(), "👤 @%s\n\n", report.User)
 		}
-		printStandupReport(report, sinceDuration)
+		printStandupReport(cmd.OutOrStdout(), report, sinceDuration)
 		if idx < len(results)-1 {
 			fmt.Fprintln(cmd.OutOrStdout())
 		}
@@ -234,47 +235,47 @@ func filterProjectByStatus(project *github.Project, assignee string, status stri
 	return items
 }
 
-func printStandupReport(report standupData, since time.Duration) {
-	fmt.Printf("✅ Done (since %s)\n", humanizeSinceLabel(since))
+func printStandupReport(w io.Writer, report standupData, since time.Duration) {
+	fmt.Fprintf(w, "✅ Done (since %s)\n", humanizeSinceLabel(since))
 	if len(report.Done) == 0 {
-		fmt.Println("  • None")
+		fmt.Fprintln(w, "  • None")
 	} else {
 		for _, item := range report.Done {
 			label := "Closed"
 			if strings.Contains(strings.ToLower(item.URL), "/pull/") || strings.Contains(strings.ToLower(item.URL), "pull") {
 				label = "Merged PR"
 			}
-			fmt.Printf("  • %s %s: %s (%s)\n", label, issueRef(item.Number, item.URL), item.Title, item.Repo)
+			fmt.Fprintf(w, "  • %s %s: %s (%s)\n", label, issueRef(item.Number, item.URL), item.Title, item.Repo)
 		}
 	}
-	fmt.Println()
+	fmt.Fprintln(w)
 
-	fmt.Println("🔵 In Progress")
+	fmt.Fprintln(w, "🔵 In Progress")
 	if len(report.InProgress) == 0 {
-		fmt.Println("  • None")
+		fmt.Fprintln(w, "  • None")
 	} else {
 		for _, item := range report.InProgress {
-			fmt.Printf("  • %s: %s (%s) — %s\n", issueRef(item.Number, item.URL), item.Title, item.Repo, activeLabel(item.UpdatedAt))
+			fmt.Fprintf(w, "  • %s: %s (%s) — %s\n", issueRef(item.Number, item.URL), item.Title, item.Repo, activeLabel(item.UpdatedAt))
 		}
 	}
-	fmt.Println()
+	fmt.Fprintln(w)
 
-	fmt.Println("🚫 Blocked")
+	fmt.Fprintln(w, "🚫 Blocked")
 	if len(report.Blocked) == 0 {
-		fmt.Println("  • None")
+		fmt.Fprintln(w, "  • None")
 	} else {
 		for _, item := range report.Blocked {
-			fmt.Printf("  • %s: %s (%s) — %s\n", issueRef(item.Number, item.URL), item.Title, item.Repo, activeLabel(item.UpdatedAt))
+			fmt.Fprintf(w, "  • %s: %s (%s) — %s\n", issueRef(item.Number, item.URL), item.Title, item.Repo, activeLabel(item.UpdatedAt))
 		}
 	}
-	fmt.Println()
+	fmt.Fprintln(w)
 
-	fmt.Println("🔍 In Review")
+	fmt.Fprintln(w, "🔍 In Review")
 	if len(report.InReview) == 0 {
-		fmt.Println("  • None")
+		fmt.Fprintln(w, "  • None")
 	} else {
 		for _, item := range report.InReview {
-			fmt.Printf("  • PR %s: %s (%s) — awaiting review\n", issueRef(item.Number, item.URL), item.Title, item.Repo)
+			fmt.Fprintf(w, "  • PR %s: %s (%s) — awaiting review\n", issueRef(item.Number, item.URL), item.Title, item.Repo)
 		}
 	}
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -3,12 +3,13 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"os"
+	"io"
 	"sort"
 	"strings"
 	"text/tabwriter"
 	"time"
 
+	"github.com/mattn/go-runewidth"
 	"github.com/maxbeizer/gh-planning/internal/github"
 	"github.com/maxbeizer/gh-planning/internal/output"
 	"github.com/spf13/cobra"
@@ -71,7 +72,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 			"number": pc.Project,
 			"items":  filtered,
 		}
-		return output.PrintJSON(payload, OutputOptions())
+		return output.PrintJSON(cmd.OutOrStdout(), payload, OutputOptions())
 	}
 
 	fmt.Fprintf(cmd.OutOrStdout(), "📊 Project: %s (#%d)\n", projectData.Title, pc.Project)
@@ -79,12 +80,12 @@ func runStatus(cmd *cobra.Command, args []string) error {
 
 	if statusOpts.Board || statusOpts.Swimlanes {
 		if statusOpts.Swimlanes {
-			printSwimlaneBoardView(filtered)
+			printSwimlaneBoardView(cmd.OutOrStdout(), filtered)
 		} else {
-			printBoardView(filtered)
+			printBoardView(cmd.OutOrStdout(), filtered)
 		}
 	} else {
-		printStatusGroups(filtered, staleDuration)
+		printStatusGroups(cmd.OutOrStdout(), filtered, staleDuration)
 	}
 	return nil
 }
@@ -121,7 +122,7 @@ func filterProjectItems(project *github.Project, assignee string, stale time.Dur
 	return filtered
 }
 
-func printStatusGroups(groups map[string][]github.ProjectItem, stale time.Duration) {
+func printStatusGroups(w io.Writer, groups map[string][]github.ProjectItem, stale time.Duration) {
 	statuses := make([]string, 0, len(groups))
 	for status := range groups {
 		statuses = append(statuses, status)
@@ -133,8 +134,8 @@ func printStatusGroups(groups map[string][]github.ProjectItem, stale time.Durati
 			continue
 		}
 		header := fmt.Sprintf("%s (%d)", status, len(items))
-		fmt.Printf("%s\n", decorateStatus(status, header))
-		w := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+		fmt.Fprintf(w, "%s\n", decorateStatus(status, header))
+		tw := tabwriter.NewWriter(w, 0, 2, 2, ' ', 0)
 		for _, item := range items {
 			assignee := "—"
 			if len(item.Assignees) > 0 {
@@ -148,10 +149,12 @@ func printStatusGroups(groups map[string][]github.ProjectItem, stale time.Durati
 			if item.URL != "" {
 				issueNum = hyperlink(item.URL, issueNum)
 			}
-			fmt.Fprintf(w, "  %s\t%s\t%s\t%s\t%s%s\n", issueNum, truncate(item.Title, 28), item.Repository, assignee, humanizeDuration(time.Since(item.UpdatedAt)), staleMark)
+			fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\t%s%s\n", issueNum, truncate(item.Title, 28), item.Repository, assignee, humanizeDuration(time.Since(item.UpdatedAt)), staleMark)
 		}
-		w.Flush()
-		fmt.Println()
+		if err := tw.Flush(); err != nil {
+			fmt.Fprintf(w, "  (flush error: %v)\n", err)
+		}
+		fmt.Fprintln(w)
 	}
 }
 
@@ -171,10 +174,10 @@ func decorateStatus(status, header string) string {
 }
 
 func truncate(value string, max int) string {
-	if len(value) <= max {
+	if runewidth.StringWidth(value) <= max {
 		return value
 	}
-	return value[:max-1] + "…"
+	return runewidth.Truncate(value, max, "…")
 }
 
 func buildStatusSummary(ctx context.Context, owner string, project int) (string, error) {

--- a/cmd/team.go
+++ b/cmd/team.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/maxbeizer/gh-planning/internal/config"
@@ -48,7 +47,7 @@ func runTeam(cmd *cobra.Command, args []string) error {
 	}
 	users := []string{}
 	if teamOpts.Team != "" {
-		users = splitTeam(teamOpts.Team)
+		users = splitAndTrim(teamOpts.Team)
 	} else {
 		users = append(users, cfg.Team...)
 	}
@@ -93,7 +92,7 @@ func runTeam(cmd *cobra.Command, args []string) error {
 			"since":   sinceTime,
 			"reports": summaries,
 		}
-		return output.PrintJSON(payload, OutputOptions())
+		return output.PrintJSON(cmd.OutOrStdout(), payload, OutputOptions())
 	}
 
 	w := cmd.OutOrStdout()
@@ -120,18 +119,6 @@ func runTeam(cmd *cobra.Command, args []string) error {
 		}
 	}
 	return nil
-}
-
-func splitTeam(value string) []string {
-	parts := strings.Split(value, ",")
-	team := []string{}
-	for _, part := range parts {
-		part = strings.TrimSpace(part)
-		if part != "" {
-			team = append(team, part)
-		}
-	}
-	return team
 }
 
 func formatLastActive(t time.Time) string {

--- a/cmd/track.go
+++ b/cmd/track.go
@@ -106,7 +106,7 @@ func runTrack(cmd *cobra.Command, args []string) error {
 	}
 
 	if OutputOptions().JSON || OutputOptions().JQ != "" {
-		return output.PrintJSON(issue, OutputOptions())
+		return output.PrintJSON(cmd.OutOrStdout(), issue, OutputOptions())
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "Created %s\n", issue.URL)
 	return nil

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 )
@@ -13,29 +14,27 @@ type Options struct {
 	JQ   string
 }
 
-func PrintJSON(data interface{}, opts Options) error {
+func PrintJSON(w io.Writer, data interface{}, opts Options) error {
 	payload, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
 		return err
 	}
 	if opts.JQ != "" {
-		return runJQ(payload, opts.JQ)
+		return runJQ(w, payload, opts.JQ)
 	}
-	fmt.Println(string(payload))
-	os.Stdout.Sync()
+	fmt.Fprintln(w, string(payload))
 	return nil
 }
 
-func runJQ(input []byte, expr string) error {
+func runJQ(w io.Writer, input []byte, expr string) error {
 	if _, err := exec.LookPath("jq"); err != nil {
 		fmt.Fprintln(os.Stderr, "jq not installed; printing JSON instead")
-		fmt.Println(string(input))
-		os.Stdout.Sync()
+		fmt.Fprintln(w, string(input))
 		return nil
 	}
 	cmd := exec.Command("jq", expr)
 	cmd.Stdin = bytes.NewReader(input)
-	cmd.Stdout = os.Stdout
+	cmd.Stdout = w
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
 }


### PR DESCRIPTION
## Summary

Addresses 6 code health issues found during deep review:

### Fixes

1. **`output.PrintJSON` now accepts `io.Writer`** (fixes #51) — was writing to `os.Stdout` directly, preventing output redirection and breaking Cobra's output management. All 21 callers updated.

2. **Board rendering functions accept `io.Writer`** (fixes #52) — `printBoardView()`, `printSwimlaneBoardView()`, and `printStatusGroups()` were using `fmt.Printf`/`os.Stdout`. Now testable and consistent with the rest of the codebase.

3. **`printStandupReport` accepts `io.Writer`** (fixes #53) — same pattern as above.

4. **`splitTeam()` consolidated into `splitAndTrim()`** (fixes #54) — removed duplicate function from `team.go`, moved canonical version to `helpers.go`. Updated callers in `team.go` and `pulse.go`.

5. **`truncate()` now uses `runewidth`** (fixes #55) — was using `len()` which breaks with emoji/CJK characters. Now consistent with `padOrTruncate()` in `board.go`.

6. **Added unit tests for core helpers** (fixes #56) — `parseDuration`, `humanizeDuration`, `projectURL`, `filterProjectItems`, `decorateStatus`, `truncate`, `findStatusOption`. Coverage in `cmd/` went from 7.7% to 10.2%.

### Also fixed
- Unhandled `w.Flush()` error in `printStatusGroups`

### Testing
- All existing tests pass (`go test -race ./...`)
- `go vet` clean
- 18 files changed, 309 insertions, 104 deletions