### PR TITLE
refactor: code health round 2 — style fixes, tests, clarifying comments

### DIFF
--- a/cmd/blocked.go
+++ b/cmd/blocked.go
@@ -25,14 +25,6 @@ var blockedCmd = &cobra.Command{
 	RunE:  runBlocked,
 }
 
-func init() {
-	blockedCmd.Flags().StringVar(&blockedOpts.By, "by", "", "Issue that is blocking (required)")
-	blockedCmd.Flags().StringVar(&blockedOpts.Repo, "repo", "", "Repository (owner/repo)")
-	blockedCmd.Flags().StringVar(&blockedOpts.Owner, "owner", "", "Project owner")
-	blockedCmd.Flags().IntVar(&blockedOpts.Project, "project", 0, "Project number")
-	_ = blockedCmd.MarkFlagRequired("by")
-}
-
 var unblockCmd = &cobra.Command{
 	Use:   "unblock <issue>",
 	Short: "Remove a block from an issue",
@@ -41,6 +33,12 @@ var unblockCmd = &cobra.Command{
 }
 
 func init() {
+	blockedCmd.Flags().StringVar(&blockedOpts.By, "by", "", "Issue that is blocking (required)")
+	blockedCmd.Flags().StringVar(&blockedOpts.Repo, "repo", "", "Repository (owner/repo)")
+	blockedCmd.Flags().StringVar(&blockedOpts.Owner, "owner", "", "Project owner")
+	blockedCmd.Flags().IntVar(&blockedOpts.Project, "project", 0, "Project number")
+	_ = blockedCmd.MarkFlagRequired("by")
+
 	unblockCmd.Flags().StringVar(&blockedOpts.Repo, "repo", "", "Repository (owner/repo)")
 }
 

--- a/cmd/log_test.go
+++ b/cmd/log_test.go
@@ -1,0 +1,27 @@
+package cmd
+
+import "testing"
+
+func TestKindPrefix(t *testing.T) {
+	tests := []struct {
+		kind string
+		want string
+	}{
+		{"decision", "🎯"},
+		{"blocker", "🚫"},
+		{"hypothesis", "💡"},
+		{"tried", "🔄"},
+		{"result", "✅"},
+		{"progress", "📝"},
+		{"unknown", "📝"},
+		{"", "📝"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			got := kindPrefix(tt.kind)
+			if got != tt.want {
+				t.Errorf("kindPrefix(%q) = %q, want %q", tt.kind, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -80,6 +80,8 @@ func runReview(cmd *cobra.Command, args []string) error {
 		conclusion := strings.ToUpper(check.Conclusion)
 		switch {
 		case conclusion == "SUCCESS" || state == "SUCCESS":
+			// Successful checks need no counter; ChecksPassing is derived
+			// from the absence of failing/pending checks below.
 		case conclusion == "FAILURE" || state == "FAILURE":
 			summary.ChecksFailing++
 		case conclusion == "NEUTRAL" || conclusion == "SKIPPED":

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -1,0 +1,86 @@
+package github
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRepositoryNameFromURL(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"https://api.github.com/repos/octocat/hello-world", "octocat/hello-world"},
+		{"https://api.github.com/repos/org/repo/", "org/repo"},
+		{"", ""},
+		{"https://api.github.com/repos/single", "repos/single"},
+		{"no-slashes", "no-slashes"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := RepositoryNameFromURL(tt.input)
+			if got != tt.want {
+				t.Errorf("RepositoryNameFromURL(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIssueURL(t *testing.T) {
+	tests := []struct {
+		name  string
+		issue SearchIssue
+		want  string
+	}{
+		{
+			name:  "prefers HTMLURL",
+			issue: SearchIssue{HTMLURL: "https://github.com/o/r/issues/1", URL: "https://api.github.com/repos/o/r/issues/1"},
+			want:  "https://github.com/o/r/issues/1",
+		},
+		{
+			name:  "falls back to URL",
+			issue: SearchIssue{URL: "https://api.github.com/repos/o/r/issues/2"},
+			want:  "https://api.github.com/repos/o/r/issues/2",
+		},
+		{
+			name:  "both empty",
+			issue: SearchIssue{},
+			want:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IssueURL(tt.issue)
+			if got != tt.want {
+				t.Errorf("IssueURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMaxTime(t *testing.T) {
+	t1 := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+	zero := time.Time{}
+
+	tests := []struct {
+		name string
+		a, b time.Time
+		want time.Time
+	}{
+		{"b is later", t1, t2, t2},
+		{"a is later", t2, t1, t2},
+		{"equal", t1, t1, t1},
+		{"a is zero", zero, t2, t2},
+		{"b is zero", t1, zero, t1},
+		{"both zero", zero, zero, zero},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := maxTime(tt.a, tt.b)
+			if !got.Equal(tt.want) {
+				t.Errorf("maxTime(%v, %v) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/github/projects.go
+++ b/internal/github/projects.go
@@ -569,9 +569,9 @@ func VerifyProject(ctx context.Context, owner string, number int) (string, error
 }
 
 func totalItems(p *Project) int {
-count := 0
-for _, items := range p.Items {
-count += len(items)
-}
-return count
+	count := 0
+	for _, items := range p.Items {
+		count += len(items)
+	}
+	return count
 }


### PR DESCRIPTION
## Summary

Addresses 3 more code health issues found in the deep review.

### Fixes

1. **Fix gofmt violation in `totalItems()`** (fixes #58) — function body was not indented with tabs in `internal/github/projects.go`.

2. **Add clarifying comment on empty SUCCESS case** (fixes #58) — `review.go:82` had an empty switch case that looked like a bug. Added comment explaining the intentional fall-through logic.

3. **Consolidate two `init()` in blocked.go** (fixes #60) — merged the two separate `init()` functions for `blockedCmd` and `unblockCmd` into one.

4. **Add unit tests for utility functions** (fixes #59):
   - `RepositoryNameFromURL()` — extracts owner/repo from API URL
   - `IssueURL()` — returns best URL for an issue  
   - `maxTime()` — returns later of two timestamps
   - `kindPrefix()` — maps log entry kinds to emoji
   - `internal/github` now has test coverage (was 0%)

### Testing
- All tests pass (`go test -race ./...`)
- `go vet` clean
- 5 files changed, 126 insertions, 13 deletions